### PR TITLE
Tests workflow add frontend job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,18 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"
           cache: "maven"
-      - name: Install Backend Dependencies
-        run: mvn clean install
+      - name: Cache Maven Dependencies
+        uses: actions/cache@v4.0.2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+            ${{ runner.os }}-m2-
+      - name: Install Backend Dependencies and Build Spring Boot Application
+        run: mvn clean package -DskipTests
       - name: Execute Backend Tests
-        run: mvn clean test
+        run: mvn test
       - name: Generate JaCoCo Code Coverage Report
         run: mvn jacoco:report
       - name: Upload JaCoCo Code Coverage Report to GitHub
@@ -35,3 +43,38 @@ jobs:
         with:
           name: JaCoCo Code Coverage Report
           path: ./back/target/site/jacoco/
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/front
+    strategy:
+      matrix:
+        node-version: [ 14.15.0, 16.10.0 ]
+    steps:
+      - name: Checkout Frontend Code
+        uses: actions/checkout@v4
+      - name: Set Up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache NPM Dependencies
+        uses: actions/cache@v4.0.2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-
+      - name: Install Frontend Dependencies
+        run: npm ci
+      - name: Build Angular Application
+        run: npm run build:prod
+      - name: Execute Frontend Tests and Generate Code Coverage Report
+        run: npm run test:prod
+      - name: Upload Coverage Report to GitHub
+        uses: actions/upload-artifact@v4.3.3
+        with:
+         name: Frontend Coverage Report
+         path: .front/coverage/bobapp/

--- a/front/karma.conf.js
+++ b/front/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
       subdir: '.',
       reporters: [
         { type: 'html' },
+        { type: 'lcov'},
         { type: 'text-summary' }
       ]
     },

--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,7 @@
     "build:prod": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:prod": "ng test --watch=false --code-coverage"
+    "test:prod": "ng test --watch=false --code-coverage --browsers=ChromeHeadless"
   },
   "private": true,
   "dependencies": {

--- a/front/package.json
+++ b/front/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:prod": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:prod": "ng test --watch=false --code-coverage"

--- a/front/package.json
+++ b/front/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:prod": "ng test --watch=false --code-coverage"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
A frontend job was added in the `.github/workflows/tests.yml` file, which is responsible for setting up the Node.js environment, caching NPM dependencies, installing frontend dependencies, building the Angular application, executing frontend tests, and generating a code coverage report.

The backend job in the .github/workflows/tests.yml file was updated to cache Maven dependencies and use mvn clean package -DskipTests and mvn test instead of mvn clean install and mvn clean test, to improve test performance.

In the `package.json` file, two new scripts were added: `test:prod` and `build:prod`. The `test:prod` script runs the tests without watch mode and generates a code coverage report, while the `build:prod` script builds the application for production. 

Lastly, in the `karma.conf.js` file, the `lcov` reporter was added to the coverage reporters, which generates a coverage report in `lcov` format after the tests are run.